### PR TITLE
🚧 Fix - Resolve app crash on missing function

### DIFF
--- a/PhotoView.android.js
+++ b/PhotoView.android.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { requireNativeComponent, View } from 'react-native';
+import { requireNativeComponent, View, Image } from 'react-native';
 import { ViewPropTypes } from 'deprecated-react-native-prop-types'
-
-const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
 export default class PhotoView extends Component {
     static propTypes = {
@@ -38,8 +36,8 @@ export default class PhotoView extends Component {
     };
 
     render() {
-        const source = resolveAssetSource(this.props.source);
-        var loadingIndicatorSource = resolveAssetSource(this.props.loadingIndicatorSource);
+        const source = Image.resolveAssetSource(this.props.source);
+        var loadingIndicatorSource = Image.resolveAssetSource(this.props.loadingIndicatorSource);
 
         if (source && source.uri === '') {
             console.warn('source.uri should not be an empty string');

--- a/PhotoView.ios.js
+++ b/PhotoView.ios.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { requireNativeComponent, View } from 'react-native';
+import { requireNativeComponent, View, Image } from 'react-native';
 import { ViewPropTypes } from 'deprecated-react-native-prop-types'
-
-const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
 export default class PhotoView extends Component {
     static propTypes = {
@@ -38,8 +36,8 @@ export default class PhotoView extends Component {
     };
 
     render() {
-        const source = resolveAssetSource(this.props.source);
-        var loadingIndicatorSource = resolveAssetSource(this.props.loadingIndicatorSource);
+        const source = Image.resolveAssetSource(this.props.source);
+        var loadingIndicatorSource = Image.resolveAssetSource(this.props.loadingIndicatorSource);
 
         if (source && source.uri === '') {
             console.warn('source.uri should not be an empty string');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-photo-view",
-  "version": "1.5.3",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lighthouse/react-native-photo-view",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Displaying photos with pinch-to-zoom",
   "main": "index.js",
   "author": {


### PR DESCRIPTION

This update **DOES NOT INCLUDE** native updates

### Description

This PR includes a fix where with React Native 0.79, it can no longer be imported separately. Instead it is now referenced via the `Image` component.